### PR TITLE
Upgrade testcli c++ language standard to Cpp17

### DIFF
--- a/testcli/testcli.vcxproj
+++ b/testcli/testcli.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Upgraded testcli debug build's c++ language standard to cpp17 to resolve string_view error